### PR TITLE
Be able to set the paths you want yardstick to examine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 group :development do
   gem 'guard'
   gem 'guard-rubocop'
+  gem 'guard-rspec'
   gem 'rubocop'
 end
 

--- a/Guardfile
+++ b/Guardfile
@@ -10,3 +10,29 @@ guard :rubocop, all_on_start: true, cli: ['--display-cop-name']do
   watch(/^(|Rakefile|Guardfile)/)
   watch(/.+\.rb$/)
 end
+
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
+#  * 'just' rspec: 'rspec'
+
+guard :rspec, cmd: 'bundle exec rspec' do
+  require 'guard/rspec/dsl'
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # Feel free to open issues for suggestions and improvements
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+end

--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ Please read the [Guard usage documentation](https://github.com/guard/guard#readm
 
 ## Options
 
-There is currently only a single option that can be passed to this guard. *all_on_start* which is *true* by default.
+*all_on_start:* Same as on any other Guard plugin. Run yardstick on all files on start or not.
+*path:* Tells yardsitck which paths to run the yardoc analysis on. Defaults to yardsticks default of *'lib/**/*.rb'*
+
 
 ```ruby
-guard :yardstick, all_on_start: false do
+guard :yardstick, all_on_start: false, path: ['app', 'config', 'lib'] do
   # ...
 end
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Please read the [Guard usage documentation](https://github.com/guard/guard#readm
 ## Options
 
 *all_on_start:* Same as on any other Guard plugin. Run yardstick on all files on start or not.
-*path:* Tells yardsitck which paths to run the yardoc analysis on. Defaults to yardsticks default of *'lib/**/*.rb'*
+
+*path:* Tells yardstick which paths to run the yardoc analysis on. Defaults to yardsticks default of *'lib'* directory.
 
 
 ```ruby

--- a/lib/guard/yardstick.rb
+++ b/lib/guard/yardstick.rb
@@ -18,7 +18,10 @@ module Guard
       super
 
       @options = {
-        all_on_start: true
+        all_on_start: true,
+        # Taken from yardsitck:
+        # https://github.com/dkubb/yardstick/blob/0aa394dd64baf5155775e6be5018d6c9844654b7/lib/yardstick/config.rb#L167
+        path:         ['lib/**/*.rb']
       }.merge(args)
     end
 
@@ -36,8 +39,7 @@ module Guard
     # @return [Void]
     def run_all
       UI.info 'Inspecting Yarddoc in all files'
-
-      inspect_with_yardstick
+      inspect_with_yardstick(options[:path])
     end
 
     # Will run when files are added
@@ -75,8 +77,9 @@ module Guard
     #
     # @api private
     # @return [Void]
-    def inspect_with_yardstick(_paths = [])
-      measurements = ::Yardstick.measure
+    def inspect_with_yardstick(paths)
+      config = ::Yardstick::Config.coerce(path: paths)
+      measurements = ::Yardstick.measure(config)
       measurements.puts
     rescue => error
       UI.error 'The following exception occurred while running ' \

--- a/lib/guard/yardstick/templates/Guardfile
+++ b/lib/guard/yardstick/templates/Guardfile
@@ -1,5 +1,9 @@
+# Options to guard-yardstick
+# all_on_start: true
+# path: ['app', 'config', 'lib']
 guard :yardstick do
   # Typical Rails setup
+  # Set path option to ['app', 'config', 'lib']
   # watch(%r{^app\/(.+)\.rb$})
   # watch(%r{^config\/initializers\/(.+)\.rb$})
   watch(%r{^lib\/(.+)\.rb$})

--- a/spec/yardstick_spec.rb
+++ b/spec/yardstick_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe Guard::Yardstick do
         subject { super()[:all_on_start] }
         it { should be_truthy }
       end
+
+      describe '[:path]' do
+        subject { super()[:path] }
+        it { should eq(['lib/**/*.rb']) }
+      end
     end
   end
 end


### PR DESCRIPTION
- Adds the option _:path_ so yardstick will examine more then just the lib directory.
- Also new uses the file path the guard is sending it on updates to tell yardstick to try and measure that file.
