### PR TITLE
Remove path option in favour of using yardstick YAML config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+measurements

--- a/.yardstick.yml
+++ b/.yardstick.yml
@@ -1,0 +1,14 @@
+---
+rules:
+  ApiTag::Presence:
+    enabled: true
+    exclude:
+      - Guard::YardstickVersion.to_s
+  ApiTag::Inclusion:
+    enabled: true
+    exclude:
+      - Guard::YardstickVersion.to_s
+  Summary::Delimiter:
+    enabled: true
+    exclude:
+      - Guard::Yardstick#yardstick_config

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in guard-yardstick.gemspec
 gemspec
 
 group :development do
-  gem 'guard'
-  gem 'guard-rubocop'
-  gem 'guard-rspec'
-  gem 'rubocop'
+  gem 'guard-rspec',   require: false
+  gem 'guard-rubocop', require: false
 end
 
 group :development, :test do
-  gem 'rspec'
+  gem 'rspec',     require: false
+  gem 'rubocop',   require: false
+  gem 'yardstick', require: false
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-guard :yardstick do
+guard :yardstick, config: '.yardstick.yml' do
   watch(/.+\.rb$/)
+  watch('.yardstick.yml') { 'lib' }
 end
 
-guard :rubocop, all_on_start: true, cli: ['--display-cop-name']do
+guard :rubocop, all_on_start: true, cli: ['--display-cop-name'] do
   watch('guard-yardstick.gemspec')
   watch(/^(|Rakefile|Guardfile)/)
   watch(/.+\.rb$/)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add `guard-yardstick` to your `Gemfile`:
 
 ```ruby
 group :development do
-  gem 'guard-yardstick'
+  gem 'guard-yardstick', require: false
 end
 ```
 
@@ -40,11 +40,11 @@ Please read the [Guard usage documentation](https://github.com/guard/guard#readm
 
 *all_on_start:* Same as on any other Guard plugin. Run yardstick on all files on start or not.
 
-*path:* Tells yardstick which paths to run the yardoc analysis on. Defaults to yardsticks default of *'lib'* directory.
+*config:* Tells yardstick where to find yardsticks configuration file if present.
 
 
 ```ruby
-guard :yardstick, all_on_start: false, path: ['app', 'config', 'lib'] do
+guard :yardstick, config: './.yardstick.yml' do
   # ...
 end
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,25 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
 require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.options = ['--display-cop-names']
+end
+
+require 'yardstick/rake/measurement'
+yardstick_options = YAML.load_file('.yardstick.yml')
+
+Yardstick::Rake::Measurement.new(:yardstick_measure, yardstick_options)
+
+require 'yardstick/rake/verify'
+
+Yardstick::Rake::Verify.new(:yardstick, yardstick_options)
+
+task default: %i[spec rubocop yardstick]

--- a/guard-yardstick.gemspec
+++ b/guard-yardstick.gemspec
@@ -1,5 +1,6 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'guard/yardstick/version'
 

--- a/lib/guard/yardstick/templates/Guardfile
+++ b/lib/guard/yardstick/templates/Guardfile
@@ -1,9 +1,21 @@
+# frozen_string_literal: true
+
 # Options to guard-yardstick
 # all_on_start: true
-# path: ['app', 'config', 'lib']
+# config: nil
 guard :yardstick do
   # Typical Rails setup
-  # Set path option to ['app', 'config', 'lib']
+  # Set path option for yardstick in ,yardstick.yml
+  # ---
+  # path:
+  #   - app
+  #   - config
+  #   - lib
+  # # Also check out the rules config
+  # # https://github.com/dkubb/yardstick#4-configuration
+  #
+  # and pass in the location of the yaml file using the config option
+  # config: '.yardstick.yml'
   # watch(%r{^app\/(.+)\.rb$})
   # watch(%r{^config\/initializers\/(.+)\.rb$})
   watch(%r{^lib\/(.+)\.rb$})

--- a/lib/guard/yardstick/templates/Guardfile
+++ b/lib/guard/yardstick/templates/Guardfile
@@ -18,5 +18,6 @@ guard :yardstick do
   # config: '.yardstick.yml'
   # watch(%r{^app\/(.+)\.rb$})
   # watch(%r{^config\/initializers\/(.+)\.rb$})
+  # watch('.yardstick.yml') { 'lib' }
   watch(%r{^lib\/(.+)\.rb$})
 end

--- a/lib/guard/yardstick/version.rb
+++ b/lib/guard/yardstick/version.rb
@@ -5,8 +5,8 @@ module Guard
   # before `class Yardstick < Guard` in yardstick.rb
   module YardstickVersion
     # http://semver.org/
-    MAJOR = 0
-    MINOR = 1
+    MAJOR = 1
+    MINOR = 0
     PATCH = 0
 
     # Returns a formatted version string

--- a/lib/guard/yardstick/version.rb
+++ b/lib/guard/yardstick/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Guard
   # A workaround for declaring `class Yardstick`
   # before `class Yardstick < Guard` in yardstick.rb
@@ -12,7 +14,6 @@ module Guard
     # @example
     #   Guard::YardstickVersion.to_s # => '0.0.0.2'
     #
-    # @api public
     # @return [String]
     def self.to_s
       [MAJOR, MINOR, PATCH].join('.')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'guard/yardstick'
 require 'guard/compat/test/helper'
 

--- a/spec/yardstick_spec.rb
+++ b/spec/yardstick_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Guard::Yardstick do
@@ -13,11 +15,6 @@ RSpec.describe Guard::Yardstick do
       describe '[:all_on_start]' do
         subject { super()[:all_on_start] }
         it { should be_truthy }
-      end
-
-      describe '[:path]' do
-        subject { super()[:path] }
-        it { should eq(['lib/**/*.rb']) }
       end
     end
   end


### PR DESCRIPTION
@X0nic I know I'm the one who added the `path` option but it was short-sighted as Yardstick has its own yaml configuration that can be shared with its rake tasks.

Think this could go out as just a minor if I add a error/warning to this. Is a dev only gem so I don't think there is any danger if effecting anything critical. If you are somehow using guard on your build server that is your own fault.  Will link to a few highlights once PR is posted.